### PR TITLE
Update on UDF vs Mysql 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,66 @@ If you don't like write in mysql schema you can change the first line of the scr
 Note: Native functions don't have 'ST_' prefix.
 
 
+
+
+## Current Function List Support vs Mysql 5.6
+
+    +-------------------------------+--------+-------+
+    | Function                      | native | msudf |
+    +-------------------------------+--------+-------+
+    | ST_Area                       | Y      | N     |
+    | ST_AsBinary                   | Y      | N     |
+    | ST_AsText                     | Y      | N     |
+    | ST_Boundary                   | N      | Y     |
+    | ST_Buffer                     | Y      | Y     |
+    | ST_Centroid                   | Y      | Y     |
+    | ST_Contains                   | Y      | Y     |
+    | ST_ConvexHull                 | N      | Y     |
+    | ST_Crosses                    | Y      | Y     |
+    | ST_Difference                 | Y      | Y     |
+    | ST_Dimension                  | Y      | N     |
+    | ST_Disjoint                   | Y      | Y     |
+    | ST_EndPoint                   | Y      | N     |
+    | ST_Envelope                   | Y      | N     |
+    | ST_ExteriorRing               | Y      | N     |
+    | ST_GeomFromText               | Y      | N     |
+    | ST_GeomFromWKB                | Y      | N     |
+    | ST_GeometryN                  | Y      | N     |
+    | ST_GeometryType               | Y      | N     |
+    | ST_InteriorRingN              | Y      | N     |
+    | ST_Intersection               | Y      | Y     |
+    | ST_Intersects                 | Y      | Y     |
+    | ST_IsClosed                   | Y      | N     |
+    | ST_IsEmpty                    | Y      | Y     |
+    | ST_IsRing                     | N      | Y     |
+    | ST_IsSimple                   | Y      | Y     |
+    | ST_IsValid                    | N      | Y     |
+    | ST_Length                     | Y      | N     |
+    | ST_Length2D                   | Y      | N     |
+    | ST_LineMerge                  | N      | Y     |
+    | ST_Line_Substring             | N      | Y     |
+    | ST_NumGeometries              | Y      | N     |
+    | ST_NumInteriorRings           | Y      | N     |
+    | ST_NumPoints                  | Y      | N     |
+    | ST_Overlaps                   | Y      | Y     |
+    | ST_PointN                     | Y      | N     |
+    | ST_PointOnSurface             | N      | Y     |
+    | ST_Reverse                    | N      | Y     |
+    | ST_SRID                       | Y      | N     |
+    | ST_Simplify                   | N      | Y     |
+    | ST_SimplifyPreserveTopology   | N      | Y     |
+    | ST_SymDifference              | Y      | Y     |
+    | ST_Touches                    | Y      | Y     |
+    | ST_Transform                  | N      | Y     |
+    | ST_Union                      | Y      | Y     |
+    | ST_Within                     | Y      | Y     |
+    | ST_X                          | Y      | N     |
+    | ST_Y                          | Y      | N     |
+    +-------------------------------+--------+-------+
+
+Note: Native functions have 'ST_' prefix.
+
+
 ## Sample Usage
 
 You can load a table with GDAL tool ogr2ogr.


### PR DESCRIPTION
As of MySQL 5.6.1, corresponding versions are available that use precise object shapes. These versions are named with an ST_ prefix. For example, Contains() uses minimum bounding rectangles, whereas ST_Contains() uses object shapes.

http://dev.mysql.com/doc/refman/5.6/en/spatial-function-reference.html

others in native with ST prefix: 

ST_Area() (deprecated 5.7.6)    Return Polygon or MultiPolygon area
ST_AsBinary(), ST_AsWKB()   Convert from internal geometry format to WKB
ST_AsText(), ST_AsWKT() Convert from internal geometry format to WKT
ST_Buffer() Return geometry of points within given distance from geometry
ST_Centroid()   Return centroid as a point
ST_Contains()   Whether one geometry contains another
ST_Crosses()    Whether one geometry crosses another
ST_Difference() Return point set difference of two geometries
ST_Dimension()  Dimension of geometry
ST_Disjoint()   Whether one geometry is disjoint from another
ST_Distance()   The distance of one geometry from another
ST_EndPoint()   End Point of LineString
ST_Envelope()   Return MBR of geometry
ST_Equals() Whether one geometry is equal to another
ST_ExteriorRing()   Return exterior ring of Polygon
ST_GeomCollFromText(), ST_GeometryCollectionFromText()  Return geometry collection from WKT
ST_GeomCollFromWKB(), ST_GeometryCollectionFromWKB()    Return geometry collection from WKB
ST_GeometryN()  Return N-th geometry from geometry collection
ST_GeometryType()   Return name of geometry type
ST_GeomFromText(), ST_GeometryFromText()    Return geometry from WKT
ST_GeomFromWKB()    Return geometry from WKB
ST_InteriorRingN()  Return N-th interior ring of Polygon
ST_Intersection()   Return point set intersection of two geometries
ST_Intersects() Whether one geometry intersects another
ST_IsClosed()   Whether a geometry is closed and simple
ST_IsEmpty()    Placeholder function
ST_IsSimple()   Whether a geometry is simple
ST_LineFromText()   Construct LineString from WKT
ST_LineFromWKB(), ST_LineStringFromWKB()    Construct LineString from WKB
ST_NumGeometries()  Return number of geometries in geometry collection
ST_NumInteriorRings()   Return number of interior rings in Polygon
ST_NumPoints()  Return number of points in LineString
ST_Overlaps()   Whether one geometry overlaps another
ST_PointFromText()  Construct Point from WKT
ST_PointFromWKB()   Construct Point from WKB
ST_PointN() Return N-th point from LineString
ST_PolyFromText(), ST_PolygonFromText() Construct Polygon from WKT
ST_PolyFromWKB(), ST_PolygonFromWKB()   Construct Polygon from WKB
ST_SRID()   Return spatial reference system ID for geometry
ST_StartPoint() Start Point of LineString
ST_SymDifference()  Return point set symmetric difference of two geometries
ST_Touches()    Whether one geometry touches another
ST_Union()  Return point set union of two geometries
ST_Within() Whether one geometry is within another
ST_X()  Return X coordinate of Point
ST_Y()  Return Y coordinate of Point
